### PR TITLE
Add different types of logging and BenchmarkType flag

### DIFF
--- a/backend/LoggingBenchmark.Aspire.AppHost/Program.cs
+++ b/backend/LoggingBenchmark.Aspire.AppHost/Program.cs
@@ -2,6 +2,25 @@ using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddProject<LoggingBenchmark_WebApp>("web-app");
+var elasticsearch = builder
+    .AddContainer("elasticsearch", "elasticsearch", "8.16.1")
+    .WithEnvironment("discovery.type", "single-node")
+    .WithEnvironment("bootstrap.memory_lock", "true")
+    .WithEnvironment("xpack.security.enabled", "false")
+    .WithEnvironment("cluster.routing.allocation.disk.threshold_enabled", "false")
+    .WithHttpEndpoint(targetPort: 9200)
+    .WithLifetime(ContainerLifetime.Persistent);
+
+builder
+    .AddContainer("kibana", "kibana", "8.16.1")
+    .WithEnvironment("ELASTICSEARCH_HOSTS", elasticsearch.GetEndpoint("http"))
+    .WithHttpEndpoint(targetPort: 5601, port: 61679)
+    .WithLifetime(ContainerLifetime.Persistent);
+
+builder.AddProject<LoggingBenchmark_WebApp>("web-app")
+    .WithEnvironment("AspireRuntime", true.ToString())
+    .WithEnvironment("BenchmarkType", "ElasticsearchHttpClient")
+    .WithEnvironment("Logging__Elasticsearch__ShipTo__NodeUris__0", elasticsearch.GetEndpoint("http"))
+    .WithEnvironment("Logging__Elasticsearch__Index__Format", "web-app-{0:yyyy.MM.dd}");
 
 builder.Build().Run();

--- a/backend/LoggingBenchmark.WebApp/LoggingBenchmark.WebApp.csproj
+++ b/backend/LoggingBenchmark.WebApp/LoggingBenchmark.WebApp.csproj
@@ -7,8 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Elastic.Extensions.Logging" Version="8.12.3"/>
     <PackageReference Include="IdGen.DependencyInjection" Version="3.0.7"/>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0"/>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0"/>
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0"/>
   </ItemGroup>
 
 </Project>

--- a/backend/LoggingBenchmark.WebApp/LoggingExtensions.cs
+++ b/backend/LoggingBenchmark.WebApp/LoggingExtensions.cs
@@ -1,0 +1,58 @@
+using Elastic.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace LoggingBenchmark.WebApp;
+
+public static class LoggingExtensions
+{
+    public static void AddLogging(this WebApplicationBuilder builder)
+    {
+        builder.Logging.ClearProviders();
+
+        var benchmarkType = builder.Configuration.GetValue<BenchmarkType>("BenchmarkType");
+
+        switch (benchmarkType)
+        {
+            case BenchmarkType.OtelConsole:
+                builder.AddOtelConsoleLogging();
+                break;
+            case BenchmarkType.ElasticsearchHttpClient:
+                builder.AddElasticsearchHttpClientLogging();
+                break;
+        }
+
+        builder.UseOtlpExporterIfAspire();
+    }
+
+    private static ILoggingBuilder AddOtelConsoleLogging(this WebApplicationBuilder builder)
+    {
+        return builder.Logging
+            .AddOpenTelemetry(options =>
+            {
+                options.IncludeFormattedMessage = true;
+                options.IncludeScopes = true;
+                options.AddConsoleExporter();
+            });
+    }
+
+    private static ILoggingBuilder AddElasticsearchHttpClientLogging(this WebApplicationBuilder builder)
+    {
+        return builder.Logging.AddElasticsearch();
+    }
+
+    private static void UseOtlpExporterIfAspire(this WebApplicationBuilder builder)
+    {
+        bool useAspire = builder.Configuration.GetValue<bool>("AspireRuntime");
+        if (useAspire)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+    }
+}
+
+public enum BenchmarkType
+{
+    OtelConsole = 1,
+    ElasticsearchHttpClient = 2
+}

--- a/backend/LoggingBenchmark.WebApp/Program.cs
+++ b/backend/LoggingBenchmark.WebApp/Program.cs
@@ -1,7 +1,10 @@
 using IdGen.DependencyInjection;
+using LoggingBenchmark.WebApp;
 using LoggingBenchmark.WebApp.Features.Projects;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.AddLogging();
 
 builder.Services.AddOpenApi();
 


### PR DESCRIPTION
### Key points

- `LoggingExtensions.cs` to accumulate logging configurations for different benchmark types.
- `Aspire.AppHost` with the elastic stack for a quick way to see logs in kibana.
- `UseOtlpExporter` only when the app starts via Aspire.