### PR TITLE
Add a server utilization dashboard to Grafana

### DIFF
--- a/terraform/environments/local/main.tf
+++ b/terraform/environments/local/main.tf
@@ -68,7 +68,7 @@ module "app" {
   network_name = module.docker_network.name
   name_prefix = local.name_prefix
   image = "drimdev/logging-benchmark:v0.1"
-  benchmark_type = "JsonConsole"
+  benchmark_type = "ElasticsearchHttpClient"
   elasticsearch_uri = "http://${module.elastic_stack.elasticsearch_host}:9200"
   postgresql_connection_string = "Host=${module.postgresql.host};Port=5432;Database=web-app;Username=${module.postgresql.user};Password=${module.postgresql.password}"
   external_port = 8888

--- a/terraform/modules/grafana-stack/.gitignore
+++ b/terraform/modules/grafana-stack/.gitignore
@@ -1,2 +1,2 @@
-configs/grafana-datasources/prometheus.yml
+configs/grafana-provisioning/datasources/prometheus.yml
 configs/prometheus.yml

--- a/terraform/modules/grafana-stack/configs/grafana-provisioning/dashboards/dashboards.yaml
+++ b/terraform/modules/grafana-stack/configs/grafana-provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "default"
+    orgId: 1
+    folder: ""
+    type: "file"
+    disableDeletion: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/terraform/modules/grafana-stack/dashboards/server-utilization.json
+++ b/terraform/modules/grafana-stack/dashboards/server-utilization.json
@@ -1,0 +1,229 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 1,
+    "links": [],
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.4.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "editorMode": "code",
+            "expr": "100 - (avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[1m])) * 100)",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "CPU usage, %",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 24,
+          "x": 0,
+          "y": 11
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.4.0",
+        "targets": [
+          {
+            "editorMode": "code",
+            "expr": "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Memory usage, %",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "schemaVersion": 40,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Server utilization",
+    "uid": "ae8asxfnwighse",
+    "version": 6,
+    "weekStart": ""
+}

--- a/terraform/modules/grafana-stack/main.tf
+++ b/terraform/modules/grafana-stack/main.tf
@@ -69,7 +69,7 @@ resource "docker_image" "grafana" {
 }
 
 resource "local_file" "grafana_prometheis_datasource" {
-  filename = "${path.module}/configs/grafana-datasources/prometheus.yml"
+  filename = "${path.module}/configs/grafana-provisioning/datasources/prometheus.yml"
   content  = templatefile("${path.module}/templates/grafana-datasources.yml.tpl", {
     name_prefix = var.name_prefix,
   })
@@ -98,8 +98,13 @@ resource "docker_container" "grafana" {
   }
 
   volumes {
-    host_path      = abspath("${path.module}/configs/grafana-datasources")
-    container_path = "/etc/grafana/provisioning/datasources"
+    host_path      = abspath("${path.module}/configs/grafana-provisioning")
+    container_path = "/etc/grafana/provisioning"
+  }
+
+  volumes {
+    host_path      = abspath("${path.module}/dashboards")
+    container_path = "/var/lib/grafana/dashboards"
   }
 
   env = [


### PR DESCRIPTION
The dashboard contains two graphs: server CPU utilization in % and server memory utilization in %. These are the main metrics we are interested in now.