### PR TITLE
[K6] Add load testing script using the open model

### DIFF
--- a/k6/script.js
+++ b/k6/script.js
@@ -1,0 +1,22 @@
+import http from 'k6/http';
+
+export const options = {
+  scenarios: {
+    load_test: {
+      executor: 'constant-arrival-rate',
+      rate: 2000,
+      timeUnit: '1s',
+      duration: '10m',
+      preAllocatedVUs: 20000,
+    },
+  },
+};
+
+export default function () {
+  // const url = 'http://localhost:8888/projects';
+  const url = 'http://app/projects';
+  const payload = JSON.stringify({ Name: 'test' });
+  const headers = { 'Content-Type': 'application/json' };
+
+  http.post(url, payload, { headers });
+}

--- a/terraform/environments/app-server/main.tf
+++ b/terraform/environments/app-server/main.tf
@@ -36,7 +36,7 @@ module "app" {
   }
   network_name = module.docker_network.name
   name_prefix = local.name_prefix
-  image = "drimdev/logging-benchmark:latest"
+  image = "drimdev/logging-benchmarks:latest"
   benchmark_type = "JsonConsole"
   elasticsearch_uri = "http://telemetry:9200"
   postgresql_connection_string = "Host=db;Port=5432;Database=web-app;Username=dbuser;Password=dbpassword"

--- a/terraform/environments/local/main.tf
+++ b/terraform/environments/local/main.tf
@@ -68,7 +68,7 @@ module "app" {
   }
   network_name = module.docker_network.name
   name_prefix = local.name_prefix
-  image = "drimdev/logging-benchmark:latest"
+  image = "drimdev/logging-benchmarks:latest"
   benchmark_type = "JsonConsole"
   elasticsearch_uri = "http://${module.elastic_stack.elasticsearch_host}:9200"
   postgresql_connection_string = "Host=${module.postgresql.host};Port=5432;Database=web-app;Username=${module.postgresql.user};Password=${module.postgresql.password}"


### PR DESCRIPTION
Create a K6 script to perform load testing at 2000 requests per second. The script uses the open model to create a constant load that does not depend on request latency. Please read https://grafana.com/docs/k6/latest/using-k6/scenarios/concepts/open-vs-closed/